### PR TITLE
feat(topics): angular new logo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@
 
 > All notable changes to this project will be documented in this file
 
+## [2.4.0-beta.4](https://github.com/open-sauced/insights/compare/v2.4.0-beta.3...v2.4.0-beta.4) (2024-02-16)
+
+
+### 🐛 Bug Fixes
+
+* now disabled button that becomes enabled no longer causes a content layout shift ([#2609](https://github.com/open-sauced/insights/issues/2609)) ([e39f638](https://github.com/open-sauced/insights/commit/e39f638740b7869bd566ea9a3d8e69d66b00b4a5))
+
 ## [2.4.0-beta.3](https://github.com/open-sauced/insights/compare/v2.4.0-beta.2...v2.4.0-beta.3) (2024-02-16)
 
 

--- a/components/atoms/Button/button.tsx
+++ b/components/atoms/Button/button.tsx
@@ -14,7 +14,7 @@ const Button = React.forwardRef<HTMLElement, ButtonsProps>(
   ({ className, children, loading, disabled, variant, showLoadingText = true, onClick, href, ...props }, ref) => {
     const styles: Record<ButtonsProps["variant"], string> = {
       primary: `bg-light-orange-9 text-light-orange-2 border-light-orange-9 hover:bg-light-orange-10 ${
-        disabled ? "bg-light-orange-7 hover:bg-light-orange-7 border-none  pointer-events-none" : ""
+        disabled ? "bg-light-orange-7 hover:bg-light-orange-7 pointer-events-none" : ""
       }`,
       default: `bg-white border-light-slate-8 text-light-slate-11 hover:bg-light-slate-2 ${
         disabled ? "bg-light-slate-4 text-light-slate-9 pointer-events-none" : ""
@@ -33,7 +33,7 @@ const Button = React.forwardRef<HTMLElement, ButtonsProps>(
     const rootClass = clsx(
       styles[variant],
       disabled && "cursor-not-allowed",
-      disabled && variant !== "destructive" && "bg-light-orange-7 hover:bg-light-orange-7 border-none",
+      disabled && variant !== "destructive" && "bg-light-orange-7 hover:bg-light-orange-7",
       "items-center inline-flex text-sm font-semibold tracking-tight border py-2 px-4 rounded-md focus-visible:border-orange-500 focus:outline-none focus-visible:ring focus-visible:ring-orange-200 whitespace-nowrap",
       className
     );

--- a/img/topic-thumbnails/angular-new.svg
+++ b/img/topic-thumbnails/angular-new.svg
@@ -1,0 +1,43 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 223 236" width="120" height="120">
+            <g clip-path="url(#a)">
+              <path
+                fill="url(#b)"
+                d="m222.077 39.192-8.019 125.923L137.387 0l84.69 39.192Zm-53.105 162.825-57.933 33.056-57.934-33.056 11.783-28.556h92.301l11.783 28.556ZM111.039 62.675l30.357 73.803H80.681l30.358-73.803ZM7.937 165.115 0 39.192 84.69 0 7.937 165.115Z"
+              />
+              <path
+                fill="url(#c)"
+                d="m222.077 39.192-8.019 125.923L137.387 0l84.69 39.192Zm-53.105 162.825-57.933 33.056-57.934-33.056 11.783-28.556h92.301l11.783 28.556ZM111.039 62.675l30.357 73.803H80.681l30.358-73.803ZM7.937 165.115 0 39.192 84.69 0 7.937 165.115Z"
+              />
+            </g>
+            <defs>
+              <linearGradient
+                id="b"
+                x1="49.009"
+                x2="225.829"
+                y1="213.75"
+                y2="129.722"
+                gradientUnits="userSpaceOnUse"
+              >
+                <stop stop-color="#E40035" />
+                <stop offset=".24" stop-color="#F60A48" />
+                <stop offset=".352" stop-color="#F20755" />
+                <stop offset=".494" stop-color="#DC087D" />
+                <stop offset=".745" stop-color="#9717E7" />
+                <stop offset="1" stop-color="#6C00F5" />
+              </linearGradient>
+              <linearGradient
+                id="c"
+                x1="41.025"
+                x2="156.741"
+                y1="28.344"
+                y2="160.344"
+                gradientUnits="userSpaceOnUse"
+              >
+                <stop stop-color="#FF31D9" />
+                <stop offset="1" stop-color="#FF5BE1" stop-opacity="0" />
+              </linearGradient>
+              <clipPath id="a">
+                <path fill="#fff" d="M0 0h223v236H0z" />
+              </clipPath>
+            </defs>
+          </svg>

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@open-sauced/insights",
-  "version": "2.4.0-beta.3",
+  "version": "2.4.0-beta.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@open-sauced/insights",
-      "version": "2.4.0-beta.3",
+      "version": "2.4.0-beta.4",
       "hasInstallScript": true,
       "license": "Apache 2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@open-sauced/insights",
   "description": "🍕The dashboard for open source discovery.",
   "keywords": [],
-  "version": "2.4.0-beta.3",
+  "version": "2.4.0-beta.4",
   "author": "Brian Douglas <brian@opensauced.pizza>",
   "private": true,
   "license": "Apache 2.0",


### PR DESCRIPTION
I am proposing to add Angular as a selectable option in the list of topics (current interests)

![image](https://github.com/monacodelisa/app-open-sauced/assets/64324417/e1523bad-0dae-45f2-be06-2e1c6b7974d4)

In this PR I am just adding the svg image,
which can be moved to the most appropriate file location.

If it's ok I would like to continue and implement 
the new topic with the next PR